### PR TITLE
Update deployment

### DIFF
--- a/inventory.ini
+++ b/inventory.ini
@@ -1,9 +1,9 @@
 [k8s_controller]
-ar-k8s-1 ansible_host=172.16.105.118 ansible_user=ibn32760
+ar-k8s-test-1 ansible_host=172.16.101.215 ansible_user=ibn32760
 
 [k8s_node]
-ar-k8s-2 ansible_host=172.16.100.152 ansible_user=ibn32760
-ar-k8s-3 ansible_host=172.16.105.220 ansible_user=ibn32760
+ar-k8s-test-2 ansible_host=172.16.100.194 ansible_user=ibn32760
+ar-k8s-test-3 ansible_host=172.16.100.249 ansible_user=ibn32760
 
 [k8s_cluster:children]
 k8s_controller

--- a/roles/k3s/defaults/main.yml
+++ b/roles/k3s/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-k3s_version: v1.23.4+k3s1
+k3s_version: v1.24.3+k3s1
 
 k3s_extra_server_args: "--flannel-backend=wireguard --disable=traefik"
 k3s_extra_agent_args: ""

--- a/roles/longhorn/tasks/deploy.yml
+++ b/roles/longhorn/tasks/deploy.yml
@@ -15,6 +15,7 @@
         namespace: longhorn-system
         create_namespace: true
         chart_ref: longhorn/longhorn
+        chart_version: 1.2.4
         values:
           defaultSettings:
             backupTarget: "{{ longhorn_s3_backup_target if longhorn_s3_backup_enabled else None }}"


### PR DESCRIPTION
## Changes

1. Update kubernetes from 1.23.4 to 1.24.3. This is currently rolled out on the cluster and has no issues.

2. Ping Longhorn helm chart version

3. Update inventory to reference the new VM's